### PR TITLE
Docker compose file for running API and MongoDB (DEVWF-T006)

### DIFF
--- a/docker-compose.init.yml
+++ b/docker-compose.init.yml
@@ -1,0 +1,10 @@
+version: "3.4"
+
+services:
+  init:
+    build: ./content-init
+    image: ghcr.io/<yourgithubaccount>/fabrikam-init:latest
+    depends_on:
+      - mongo
+    environment:
+      MONGODB_CONNECTION: mongodb://mongo:27017/contentdb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3.4"
+services:
+  api:
+    image: ghcr.io/<yourgithubaccount>/fabrikam-api:latest
+    ports:
+      - "3001:3001"

--- a/local.docker-compose.yml
+++ b/local.docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.4"
+services:
+  mongo:
+    image: mongo
+    restart: always
+
+  api:
+    build: ./content-api
+    image: local-fabrikam-api
+    depends_on:
+      - mongo
+    environment:
+      MONGODB_CONNECTION: mongodb://mongo:27017/contentdb    


### PR DESCRIPTION

# Instructions to Fix the exercise

Added 3 docker-compose files to the root of the repo. the `docker-compose.yml` contains the containers that always need to be started. This can be extended by adding another file for the initialization of the database. For our DB `docker-compose.init.yml` has been added. To run the application locally, you can add the file `local.docker-compose.yml` that overrides some settings and starts the application.

To build and run these containers

```bash
docker-compose -f docker-compose.yml -f local.docker-compose.yml -f docker-compose.init.yml build
docker-compose -f docker-compose.yml -f local.docker-compose.yml -f docker-compose.init.yml up

```

To stop
```bash
docker-compose -f docker-compose.yml -f local.docker-compose.yml -f docker-compose.init.yml down
```

Linked to [AB#5](https://dev.azure.com/odluser419844/fdad430a-5deb-49f8-b309-1fdc5d7bf529/_workitems/edit/5)